### PR TITLE
feat(apps): add app launcher with health check monitoring

### DIFF
--- a/apps/dashboard/src/components/layout/TopNav.tsx
+++ b/apps/dashboard/src/components/layout/TopNav.tsx
@@ -5,8 +5,9 @@ import { useHotkeys } from "../../lib/useHotkeys";
 
 const navItems = [
 	{ to: "/", label: "Dashboard", key: "1" },
-	{ to: "/servers", label: "Servers", key: "2" },
-	{ to: "/settings", label: "Settings", key: "3" },
+	{ to: "/apps", label: "Apps", key: "2" },
+	{ to: "/servers", label: "Servers", key: "3" },
+	{ to: "/settings", label: "Settings", key: "4" },
 ] as const;
 
 export function TopNav() {
@@ -15,6 +16,7 @@ export function TopNav() {
 
 	useHotkeys({
 		"g+h": () => navigate({ to: "/" }),
+		"g+a": () => navigate({ to: "/apps" }),
 		"g+s": () => navigate({ to: "/servers" }),
 		"g+,": () => navigate({ to: "/settings" }),
 	});

--- a/apps/dashboard/src/components/ui/CommandPalette.tsx
+++ b/apps/dashboard/src/components/ui/CommandPalette.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 import { Command } from "cmdk";
-import { Home, Play, Plus, Server, Settings, Square } from "lucide-react";
+import { Grid, Home, Play, Plus, Server, Settings, Square } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { client } from "../../lib/api";
@@ -114,6 +114,16 @@ export function CommandPalette() {
 								<span>Dashboard</span>
 								<kbd className="ml-auto text-xs text-text-tertiary bg-background px-1.5 py-0.5 rounded">
 									g h
+								</kbd>
+							</Command.Item>
+							<Command.Item
+								onSelect={() => runCommand(() => navigate({ to: "/apps" }))}
+								className="flex items-center gap-3 px-3 py-2 rounded cursor-pointer text-text-secondary data-[selected=true]:bg-surface-elevated data-[selected=true]:text-text-primary"
+							>
+								<Grid size={16} />
+								<span>Apps</span>
+								<kbd className="ml-auto text-xs text-text-tertiary bg-background px-1.5 py-0.5 rounded">
+									g a
 								</kbd>
 							</Command.Item>
 							<Command.Item

--- a/apps/dashboard/src/components/ui/MobileNav.tsx
+++ b/apps/dashboard/src/components/ui/MobileNav.tsx
@@ -1,8 +1,9 @@
 import { Link, useLocation } from "@tanstack/react-router";
-import { Home, Plus, Server, Settings } from "lucide-react";
+import { Grid, Home, Plus, Server, Settings } from "lucide-react";
 
 const navItems = [
 	{ to: "/", icon: Home, label: "Home" },
+	{ to: "/apps", icon: Grid, label: "Apps" },
 	{ to: "/servers", icon: Server, label: "Servers" },
 	{ to: "/settings", icon: Settings, label: "Settings" },
 ] as const;
@@ -12,7 +13,7 @@ export function MobileNav() {
 
 	return (
 		<nav className="md:hidden fixed bottom-0 left-0 right-0 bg-surface border-t border-border z-50 pb-safe">
-			<div className="grid grid-cols-4 items-center">
+			<div className="grid grid-cols-5 items-center">
 				{navItems.map(({ to, icon: Icon, label }) => {
 					const isActive =
 						location.pathname === to || (to !== "/" && location.pathname.startsWith(to));

--- a/apps/dashboard/src/components/ui/Panel.tsx
+++ b/apps/dashboard/src/components/ui/Panel.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 interface PanelProps {
-	title: string;
+	title: ReactNode;
 	children: ReactNode;
 	actions?: ReactNode;
 	className?: string;

--- a/apps/dashboard/src/routeTree.gen.ts
+++ b/apps/dashboard/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ServersRouteImport } from './routes/servers'
+import { Route as AppsRouteImport } from './routes/apps'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ServersNewRouteImport } from './routes/servers_.new'
 
@@ -22,6 +23,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const ServersRoute = ServersRouteImport.update({
   id: '/servers',
   path: '/servers',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AppsRoute = AppsRouteImport.update({
+  id: '/apps',
+  path: '/apps',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -37,12 +43,14 @@ const ServersNewRoute = ServersNewRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/apps': typeof AppsRoute
   '/servers': typeof ServersRoute
   '/settings': typeof SettingsRoute
   '/servers/new': typeof ServersNewRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/apps': typeof AppsRoute
   '/servers': typeof ServersRoute
   '/settings': typeof SettingsRoute
   '/servers/new': typeof ServersNewRoute
@@ -50,20 +58,22 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/apps': typeof AppsRoute
   '/servers': typeof ServersRoute
   '/settings': typeof SettingsRoute
   '/servers_/new': typeof ServersNewRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/servers' | '/settings' | '/servers/new'
+  fullPaths: '/' | '/apps' | '/servers' | '/settings' | '/servers/new'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/servers' | '/settings' | '/servers/new'
-  id: '__root__' | '/' | '/servers' | '/settings' | '/servers_/new'
+  to: '/' | '/apps' | '/servers' | '/settings' | '/servers/new'
+  id: '__root__' | '/' | '/apps' | '/servers' | '/settings' | '/servers_/new'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AppsRoute: typeof AppsRoute
   ServersRoute: typeof ServersRoute
   SettingsRoute: typeof SettingsRoute
   ServersNewRoute: typeof ServersNewRoute
@@ -85,6 +95,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServersRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/apps': {
+      id: '/apps'
+      path: '/apps'
+      fullPath: '/apps'
+      preLoaderRoute: typeof AppsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -104,6 +121,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AppsRoute: AppsRoute,
   ServersRoute: ServersRoute,
   SettingsRoute: SettingsRoute,
   ServersNewRoute: ServersNewRoute,

--- a/apps/dashboard/src/routes/apps.tsx
+++ b/apps/dashboard/src/routes/apps.tsx
@@ -1,0 +1,454 @@
+import { useForm } from "@tanstack/react-form";
+import { createFileRoute } from "@tanstack/react-router";
+import {
+	AlertCircle,
+	CheckCircle,
+	Circle,
+	ExternalLink,
+	Film,
+	Hammer,
+	Laptop,
+	LayoutGrid,
+	Loader2,
+	MonitorDot,
+	Plus,
+	RefreshCw,
+	Trash2,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button, Input, Label, Panel } from "../components/ui";
+import { client } from "../lib/api";
+
+export const Route = createFileRoute("/apps")({
+	component: AppsPage,
+});
+
+type AppsResponse = Awaited<ReturnType<typeof client.api.apps.get>>["data"];
+type App = NonNullable<AppsResponse>[number];
+type AppCategory = App["category"];
+
+const categoryIcons: Record<string, React.ReactNode> = {
+	media: <Film size={14} />,
+	tools: <Hammer size={14} />,
+	monitoring: <MonitorDot size={14} />,
+	development: <Laptop size={14} />,
+	other: <LayoutGrid size={14} />,
+};
+
+const categoryLabels: Record<string, string> = {
+	media: "Media",
+	tools: "Tools",
+	monitoring: "Monitoring",
+	development: "Development",
+	other: "Other",
+};
+
+function AppsPage() {
+	const [apps, setApps] = useState<NonNullable<AppsResponse>>([]);
+	const [loading, setLoading] = useState(true);
+	const [showAddForm, setShowAddForm] = useState(false);
+
+	const fetchApps = useCallback(async () => {
+		try {
+			const { data } = await client.api.apps.get();
+			if (data) setApps(data);
+		} catch (error) {
+			console.error("Failed to fetch apps:", error);
+			toast.error("Failed to load apps");
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		fetchApps();
+	}, [fetchApps]);
+
+	const handleDelete = async (id: string, name: string) => {
+		if (!confirm(`Delete "${name}"?`)) return;
+		try {
+			await client.api.apps({ id }).delete();
+			toast.success(`${name} deleted`);
+			fetchApps();
+		} catch {
+			toast.error(`Failed to delete ${name}`);
+		}
+	};
+
+	const handleRefresh = async (id: string) => {
+		try {
+			await client.api.apps({ id }).refresh.post();
+			fetchApps();
+		} catch {
+			toast.error("Failed to refresh status");
+		}
+	};
+
+	// Group apps by category
+	const groupedApps = apps.reduce(
+		(acc, app) => {
+			const cat = app.category || "other";
+			if (!acc[cat]) acc[cat] = [];
+			acc[cat].push(app);
+			return acc;
+		},
+		{} as Record<string, App[]>
+	);
+
+	const categoryOrder = ["media", "tools", "monitoring", "development", "other"];
+	const sortedCategories = categoryOrder.filter((cat) => groupedApps[cat]?.length > 0);
+
+	return (
+		<div className="space-y-4">
+			{/* Header */}
+			<div className="flex items-center justify-between px-3 py-2 bg-surface border border-border rounded text-xs">
+				<div className="flex items-center gap-4">
+					<span className="text-text-primary font-medium">App Launcher</span>
+					<span className="text-text-tertiary">{apps.length} apps</span>
+				</div>
+				<div className="flex items-center gap-2">
+					<Button size="sm" variant="ghost" onClick={fetchApps} title="Refresh">
+						<RefreshCw size={12} />
+					</Button>
+					<Button size="sm" onClick={() => setShowAddForm(true)}>
+						<Plus size={12} />
+						Add App
+					</Button>
+				</div>
+			</div>
+
+			{/* Add Form */}
+			{showAddForm && (
+				<AddAppForm
+					onClose={() => setShowAddForm(false)}
+					onSuccess={() => {
+						setShowAddForm(false);
+						fetchApps();
+					}}
+				/>
+			)}
+
+			{/* Apps Grid */}
+			{loading ? (
+				<div className="text-center py-12 text-text-tertiary">Loading...</div>
+			) : apps.length === 0 ? (
+				<Panel title="No Apps">
+					<div className="text-center py-8 text-text-tertiary">
+						<p>No apps configured yet.</p>
+						<Button size="sm" className="mt-4" onClick={() => setShowAddForm(true)}>
+							<Plus size={12} />
+							Add your first app
+						</Button>
+					</div>
+				</Panel>
+			) : (
+				<div className="space-y-4">
+					{sortedCategories.map((category) => (
+						<Panel
+							key={category}
+							title={
+								<span className="flex items-center gap-2">
+									{categoryIcons[category]}
+									{categoryLabels[category]}
+								</span>
+							}
+						>
+							<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+								{groupedApps[category].map((app) => (
+									<AppCard
+										key={app.id}
+										app={app}
+										onDelete={() => handleDelete(app.id, app.name)}
+										onRefresh={() => handleRefresh(app.id)}
+									/>
+								))}
+							</div>
+						</Panel>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function AppCard({
+	app,
+	onDelete,
+	onRefresh,
+}: {
+	app: App;
+	onDelete: () => void;
+	onRefresh: () => void;
+}) {
+	const statusIcon =
+		app.status === "up" ? (
+			<CheckCircle size={12} className="text-success" />
+		) : app.status === "down" ? (
+			<AlertCircle size={12} className="text-error" />
+		) : (
+			<Circle size={12} className="text-text-tertiary" />
+		);
+
+	return (
+		<div className="group relative p-3 bg-surface-elevated/50 hover:bg-surface-elevated rounded border border-border transition-colors">
+			<a href={app.url} target="_blank" rel="noopener noreferrer" className="block">
+				<div className="flex items-start gap-3">
+					<div className="text-2xl">{app.icon || "🔗"}</div>
+					<div className="flex-1 min-w-0">
+						<div className="flex items-center gap-2">
+							<span className="font-medium text-sm truncate">{app.name}</span>
+							{statusIcon}
+						</div>
+						{app.description && (
+							<p className="text-xs text-text-tertiary mt-0.5 line-clamp-2">{app.description}</p>
+						)}
+					</div>
+					<ExternalLink
+						size={12}
+						className="text-text-tertiary opacity-0 group-hover:opacity-100 transition-opacity"
+					/>
+				</div>
+			</a>
+			{/* Action buttons */}
+			<div className="absolute top-2 right-2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+				<button
+					type="button"
+					onClick={(e) => {
+						e.preventDefault();
+						onRefresh();
+					}}
+					className="p-1 rounded text-text-tertiary hover:text-text-primary hover:bg-surface"
+					title="Refresh status"
+				>
+					<RefreshCw size={10} />
+				</button>
+				<button
+					type="button"
+					onClick={(e) => {
+						e.preventDefault();
+						onDelete();
+					}}
+					className="p-1 rounded text-text-tertiary hover:text-error hover:bg-error-bg"
+					title="Delete"
+				>
+					<Trash2 size={10} />
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function AddAppForm({ onClose, onSuccess }: { onClose: () => void; onSuccess: () => void }) {
+	const [error, setError] = useState<string | null>(null);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	const form = useForm({
+		defaultValues: {
+			name: "",
+			url: "",
+			icon: "",
+			category: "other" as AppCategory,
+			description: "",
+			healthCheckUrl: "",
+		},
+		onSubmit: async ({ value }) => {
+			setIsSubmitting(true);
+			setError(null);
+
+			try {
+				const { error: apiError } = await client.api.apps.post({
+					name: value.name.trim(),
+					url: value.url.trim(),
+					icon: value.icon?.trim() || undefined,
+					category: value.category,
+					description: value.description?.trim() || undefined,
+					healthCheckUrl: value.healthCheckUrl?.trim() || undefined,
+				});
+
+				if (apiError) {
+					const errorValue = apiError.value;
+					const errorMessage =
+						errorValue && typeof errorValue === "object" && "error" in errorValue
+							? String(errorValue.error)
+							: "Failed to add app";
+					setError(errorMessage);
+					setIsSubmitting(false);
+					return;
+				}
+
+				toast.success(`${value.name} added`);
+				onSuccess();
+			} catch (e) {
+				setError(e instanceof Error ? e.message : "Failed to add app");
+				setIsSubmitting(false);
+			}
+		},
+	});
+
+	return (
+		<Panel title="Add App">
+			<form
+				onSubmit={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					form.handleSubmit();
+				}}
+				className="space-y-4"
+			>
+				<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<form.Field
+						name="name"
+						children={(field) => (
+							<FormField label="Name" required>
+								<Input
+									id="name"
+									type="text"
+									placeholder="Jellyfin"
+									value={field.state.value}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value)}
+								/>
+							</FormField>
+						)}
+					/>
+
+					<form.Field
+						name="url"
+						children={(field) => (
+							<FormField label="URL" required>
+								<Input
+									id="url"
+									type="url"
+									placeholder="https://jellyfin.example.com"
+									value={field.state.value}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value)}
+									className="font-mono"
+								/>
+							</FormField>
+						)}
+					/>
+
+					<form.Field
+						name="icon"
+						children={(field) => (
+							<FormField label="Icon (emoji)">
+								<Input
+									id="icon"
+									type="text"
+									placeholder="🎬"
+									value={field.state.value}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value)}
+									maxLength={4}
+									className="w-20"
+								/>
+							</FormField>
+						)}
+					/>
+
+					<form.Field
+						name="category"
+						children={(field) => (
+							<FormField label="Category">
+								<select
+									id="category"
+									value={field.state.value}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value as AppCategory)}
+									className="w-full px-3 py-2 bg-background border border-border rounded text-sm focus:outline-none focus:border-accent"
+								>
+									<option value="media">Media</option>
+									<option value="tools">Tools</option>
+									<option value="monitoring">Monitoring</option>
+									<option value="development">Development</option>
+									<option value="other">Other</option>
+								</select>
+							</FormField>
+						)}
+					/>
+
+					<form.Field
+						name="description"
+						children={(field) => (
+							<FormField label="Description" fullWidth>
+								<Input
+									id="description"
+									type="text"
+									placeholder="Media streaming server"
+									value={field.state.value}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value)}
+								/>
+							</FormField>
+						)}
+					/>
+
+					<form.Field
+						name="healthCheckUrl"
+						children={(field) => (
+							<FormField label="Health Check URL" hint="Used to show up/down status" fullWidth>
+								<Input
+									id="healthCheckUrl"
+									type="url"
+									placeholder="https://jellyfin.example.com/health"
+									value={field.state.value}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value)}
+									className="font-mono"
+								/>
+							</FormField>
+						)}
+					/>
+				</div>
+
+				{/* Error Message */}
+				{error && (
+					<div className="px-3 py-2 rounded bg-error-bg border border-error text-error text-sm">
+						{error}
+					</div>
+				)}
+
+				{/* Actions */}
+				<div className="flex items-center justify-end gap-2 pt-2 border-t border-border">
+					<Button type="button" variant="ghost" onClick={onClose} disabled={isSubmitting}>
+						Cancel
+					</Button>
+					<Button type="submit" disabled={isSubmitting}>
+						{isSubmitting && <Loader2 size={14} className="animate-spin" />}
+						{isSubmitting ? "Adding..." : "Add App"}
+					</Button>
+				</div>
+			</form>
+		</Panel>
+	);
+}
+
+function FormField({
+	label,
+	hint,
+	error,
+	required,
+	fullWidth,
+	children,
+}: {
+	label: string;
+	hint?: string;
+	error?: string;
+	required?: boolean;
+	fullWidth?: boolean;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className={fullWidth ? "md:col-span-2" : ""}>
+			<Label className="block text-xs text-text-tertiary mb-1">
+				{label}
+				{required && " *"}
+			</Label>
+			{children}
+			{error && <p className="text-error text-xs mt-1">{error}</p>}
+			{hint && !error && <p className="text-xs text-text-tertiary mt-1">{hint}</p>}
+		</div>
+	);
+}

--- a/apps/nexus/src/domains/apps/index.ts
+++ b/apps/nexus/src/domains/apps/index.ts
@@ -1,0 +1,4 @@
+export * from "./routes";
+export * from "./schema";
+export * from "./service";
+export * from "./types";

--- a/apps/nexus/src/domains/apps/repository.ts
+++ b/apps/nexus/src/domains/apps/repository.ts
@@ -1,0 +1,34 @@
+import { eq } from "drizzle-orm";
+import { appsDb } from "../../infra/db";
+import { type App, apps, type NewApp } from "./schema";
+
+export const appRepository = {
+	async findAll(): Promise<App[]> {
+		return appsDb.select().from(apps).orderBy(apps.sortOrder, apps.name);
+	},
+
+	async findById(id: string): Promise<App | undefined> {
+		const results = await appsDb.select().from(apps).where(eq(apps.id, id));
+		return results[0];
+	},
+
+	async create(data: NewApp): Promise<App> {
+		const results = await appsDb.insert(apps).values(data).returning();
+		return results[0];
+	},
+
+	async update(id: string, data: Partial<NewApp>): Promise<App | undefined> {
+		const now = new Date().toISOString();
+		const results = await appsDb
+			.update(apps)
+			.set({ ...data, updatedAt: now })
+			.where(eq(apps.id, id))
+			.returning();
+		return results[0];
+	},
+
+	async delete(id: string): Promise<boolean> {
+		const results = await appsDb.delete(apps).where(eq(apps.id, id)).returning();
+		return results.length > 0;
+	},
+};

--- a/apps/nexus/src/domains/apps/routes.ts
+++ b/apps/nexus/src/domains/apps/routes.ts
@@ -1,0 +1,104 @@
+import { Elysia, t } from "elysia";
+import { appService } from "./service";
+import {
+	ApiError,
+	AppListResponse,
+	AppParams,
+	AppResponse,
+	AppWithStatusResponse,
+	CreateAppBody,
+	UpdateAppBody,
+} from "./types";
+
+export const appRoutes = new Elysia({ prefix: "/apps" })
+	.get(
+		"/",
+		async () => {
+			return await appService.list();
+		},
+		{
+			detail: { tags: ["Apps"], summary: "List all apps with status" },
+			response: { 200: AppListResponse },
+		}
+	)
+
+	.get(
+		"/:id",
+		async ({ params, set }) => {
+			const app = await appService.get(params.id);
+			if (!app) {
+				set.status = 404;
+				return { error: "App not found" };
+			}
+			return app;
+		},
+		{
+			detail: { tags: ["Apps"], summary: "Get app by ID" },
+			params: AppParams,
+			response: { 200: AppWithStatusResponse, 404: ApiError },
+		}
+	)
+
+	.post(
+		"/",
+		async ({ body }) => {
+			return await appService.create(body);
+		},
+		{
+			detail: { tags: ["Apps"], summary: "Create a new app" },
+			body: CreateAppBody,
+			response: { 200: AppResponse },
+		}
+	)
+
+	.patch(
+		"/:id",
+		async ({ params, body, set }) => {
+			const app = await appService.update(params.id, body);
+			if (!app) {
+				set.status = 404;
+				return { error: "App not found" };
+			}
+			return app;
+		},
+		{
+			detail: { tags: ["Apps"], summary: "Update an app" },
+			params: AppParams,
+			body: UpdateAppBody,
+			response: { 200: AppResponse, 404: ApiError },
+		}
+	)
+
+	.delete(
+		"/:id",
+		async ({ params, set }) => {
+			const deleted = await appService.delete(params.id);
+			if (!deleted) {
+				set.status = 404;
+				return { error: "App not found" };
+			}
+			return { success: true };
+		},
+		{
+			detail: { tags: ["Apps"], summary: "Delete an app" },
+			params: AppParams,
+			response: { 200: t.Object({ success: t.Boolean() }), 404: ApiError },
+		}
+	)
+
+	.post(
+		"/:id/refresh",
+		async ({ params }) => {
+			const status = await appService.refreshStatus(params.id);
+			return { status };
+		},
+		{
+			detail: { tags: ["Apps"], summary: "Refresh app health status" },
+			params: AppParams,
+			response: {
+				200: t.Object({
+					status: t.Union([t.Literal("up"), t.Literal("down"), t.Literal("unknown")]),
+				}),
+			},
+		}
+	);

--- a/apps/nexus/src/domains/apps/schema.ts
+++ b/apps/nexus/src/domains/apps/schema.ts
@@ -1,0 +1,21 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const apps = sqliteTable("apps", {
+	id: text("id").primaryKey(),
+	name: text("name").notNull(),
+	url: text("url").notNull(),
+	icon: text("icon"), // lucide icon name or emoji
+	category: text("category", {
+		enum: ["media", "tools", "monitoring", "development", "other"],
+	})
+		.notNull()
+		.default("other"),
+	healthCheckUrl: text("health_check_url"),
+	description: text("description"),
+	sortOrder: integer("sort_order").notNull().default(0),
+	createdAt: text("created_at").notNull(),
+	updatedAt: text("updated_at").notNull(),
+});
+
+export type App = typeof apps.$inferSelect;
+export type NewApp = typeof apps.$inferInsert;

--- a/apps/nexus/src/domains/apps/service.ts
+++ b/apps/nexus/src/domains/apps/service.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from "node:crypto";
+import logger from "logger";
+import { appRepository } from "./repository";
+import type { App } from "./schema";
+
+type AppStatus = "up" | "down" | "unknown";
+
+interface AppWithStatus extends App {
+	status: AppStatus;
+}
+
+class AppService {
+	private statusCache = new Map<string, { status: AppStatus; checkedAt: number }>();
+	private readonly CACHE_TTL = 30000; // 30 seconds
+
+	async list(): Promise<AppWithStatus[]> {
+		const apps = await appRepository.findAll();
+		const appsWithStatus = await Promise.all(
+			apps.map(async (app) => ({
+				...app,
+				status: await this.getStatus(app),
+			}))
+		);
+		return appsWithStatus;
+	}
+
+	async get(id: string): Promise<AppWithStatus | null> {
+		const app = await appRepository.findById(id);
+		if (!app) return null;
+		return {
+			...app,
+			status: await this.getStatus(app),
+		};
+	}
+
+	async create(data: {
+		name: string;
+		url: string;
+		icon?: string;
+		category?: App["category"];
+		healthCheckUrl?: string;
+		description?: string;
+		sortOrder?: number;
+	}): Promise<App> {
+		const now = new Date().toISOString();
+		return appRepository.create({
+			id: randomUUID().slice(0, 8),
+			name: data.name,
+			url: data.url,
+			icon: data.icon ?? null,
+			category: data.category ?? "other",
+			healthCheckUrl: data.healthCheckUrl ?? null,
+			description: data.description ?? null,
+			sortOrder: data.sortOrder ?? 0,
+			createdAt: now,
+			updatedAt: now,
+		});
+	}
+
+	async update(
+		id: string,
+		data: Partial<{
+			name: string;
+			url: string;
+			icon: string | null;
+			category: App["category"];
+			healthCheckUrl: string | null;
+			description: string | null;
+			sortOrder: number;
+		}>
+	): Promise<App | null> {
+		// Clear cache when app is updated
+		this.statusCache.delete(id);
+		return (await appRepository.update(id, data)) ?? null;
+	}
+
+	async delete(id: string): Promise<boolean> {
+		this.statusCache.delete(id);
+		return appRepository.delete(id);
+	}
+
+	private async getStatus(app: App): Promise<AppStatus> {
+		if (!app.healthCheckUrl) return "unknown";
+
+		// Check cache
+		const cached = this.statusCache.get(app.id);
+		if (cached && Date.now() - cached.checkedAt < this.CACHE_TTL) {
+			return cached.status;
+		}
+
+		// Perform health check
+		const status = await this.checkHealth(app.healthCheckUrl);
+		this.statusCache.set(app.id, { status, checkedAt: Date.now() });
+		return status;
+	}
+
+	private async checkHealth(url: string): Promise<AppStatus> {
+		try {
+			const controller = new AbortController();
+			const timeout = setTimeout(() => controller.abort(), 5000);
+
+			const response = await fetch(url, {
+				method: "HEAD",
+				signal: controller.signal,
+			});
+
+			clearTimeout(timeout);
+			return response.ok ? "up" : "down";
+		} catch (error) {
+			logger.debug({ url, error }, "Health check failed");
+			return "down";
+		}
+	}
+
+	async refreshStatus(id: string): Promise<AppStatus> {
+		const app = await appRepository.findById(id);
+		if (!app || !app.healthCheckUrl) return "unknown";
+
+		this.statusCache.delete(id);
+		return this.getStatus(app);
+	}
+}
+
+export const appService = new AppService();

--- a/apps/nexus/src/domains/apps/types.ts
+++ b/apps/nexus/src/domains/apps/types.ts
@@ -1,0 +1,66 @@
+import { t } from "elysia";
+
+export const AppCategory = t.Union([
+	t.Literal("media"),
+	t.Literal("tools"),
+	t.Literal("monitoring"),
+	t.Literal("development"),
+	t.Literal("other"),
+]);
+
+export const AppParams = t.Object({
+	id: t.String(),
+});
+
+export const CreateAppBody = t.Object({
+	name: t.String({ minLength: 1 }),
+	url: t.String({ minLength: 1 }),
+	icon: t.Optional(t.String()),
+	category: t.Optional(AppCategory),
+	healthCheckUrl: t.Optional(t.String()),
+	description: t.Optional(t.String()),
+	sortOrder: t.Optional(t.Number()),
+});
+
+export const UpdateAppBody = t.Object({
+	name: t.Optional(t.String({ minLength: 1 })),
+	url: t.Optional(t.String({ minLength: 1 })),
+	icon: t.Optional(t.Nullable(t.String())),
+	category: t.Optional(AppCategory),
+	healthCheckUrl: t.Optional(t.Nullable(t.String())),
+	description: t.Optional(t.Nullable(t.String())),
+	sortOrder: t.Optional(t.Number()),
+});
+
+export const AppResponse = t.Object({
+	id: t.String(),
+	name: t.String(),
+	url: t.String(),
+	icon: t.Nullable(t.String()),
+	category: AppCategory,
+	healthCheckUrl: t.Nullable(t.String()),
+	description: t.Nullable(t.String()),
+	sortOrder: t.Number(),
+	createdAt: t.String(),
+	updatedAt: t.String(),
+});
+
+export const AppWithStatusResponse = t.Object({
+	id: t.String(),
+	name: t.String(),
+	url: t.String(),
+	icon: t.Nullable(t.String()),
+	category: AppCategory,
+	healthCheckUrl: t.Nullable(t.String()),
+	description: t.Nullable(t.String()),
+	sortOrder: t.Number(),
+	createdAt: t.String(),
+	updatedAt: t.String(),
+	status: t.Union([t.Literal("up"), t.Literal("down"), t.Literal("unknown")]),
+});
+
+export const AppListResponse = t.Array(AppWithStatusResponse);
+
+export const ApiError = t.Object({
+	error: t.String(),
+});

--- a/apps/nexus/src/domains/system-info/service.ts
+++ b/apps/nexus/src/domains/system-info/service.ts
@@ -600,6 +600,7 @@ class SystemInfoService {
 			{ name: "core.sqlite", domain: "core" },
 			{ name: "system-info.sqlite", domain: "system-info" },
 			{ name: "ops.sqlite", domain: "ops" },
+			{ name: "apps.sqlite", domain: "apps" },
 		];
 
 		for (const { name, domain } of dbFiles) {

--- a/apps/nexus/src/infra/db-push.ts
+++ b/apps/nexus/src/infra/db-push.ts
@@ -133,4 +133,29 @@ opsDb.run(sql`CREATE INDEX IF NOT EXISTS idx_operations_started_at ON operations
 logger.info({ database: "ops" }, "Schema pushed");
 opsSqlite.close();
 
+// Push apps schema
+logger.info({ database: "apps" }, "Pushing schema");
+const appsSqlite = new Database(join(dbPath, "apps.sqlite"), { create: true });
+appsSqlite.exec("PRAGMA journal_mode = WAL;");
+const appsDb = drizzle(appsSqlite);
+
+appsDb.run(sql`
+  CREATE TABLE IF NOT EXISTS apps (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    url TEXT NOT NULL,
+    icon TEXT,
+    category TEXT NOT NULL DEFAULT 'other',
+    health_check_url TEXT,
+    description TEXT,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )
+`);
+appsDb.run(sql`CREATE INDEX IF NOT EXISTS idx_apps_category ON apps(category)`);
+appsDb.run(sql`CREATE INDEX IF NOT EXISTS idx_apps_sort_order ON apps(sort_order)`);
+logger.info({ database: "apps" }, "Schema pushed");
+appsSqlite.close();
+
 logger.info("All schemas pushed successfully");

--- a/apps/nexus/src/infra/db.ts
+++ b/apps/nexus/src/infra/db.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import { join } from "node:path";
 import { drizzle } from "drizzle-orm/bun-sqlite";
+import * as appsSchema from "../domains/apps/schema";
 import * as coreSchema from "../domains/core/schema";
 import * as gameServerSchema from "../domains/game-servers/schema";
 import * as opsSchema from "../domains/ops/schema";
@@ -22,12 +23,16 @@ const systemInfoSqlite = new Database(join(dbPath, "system-info.sqlite"), {
 const opsSqlite = new Database(join(dbPath, "ops.sqlite"), {
 	create: true,
 });
+const appsSqlite = new Database(join(dbPath, "apps.sqlite"), {
+	create: true,
+});
 
 // Enable WAL mode for better concurrency
 minecraftSqlite.exec("PRAGMA journal_mode = WAL;");
 coreSqlite.exec("PRAGMA journal_mode = WAL;");
 systemInfoSqlite.exec("PRAGMA journal_mode = WAL;");
 opsSqlite.exec("PRAGMA journal_mode = WAL;");
+appsSqlite.exec("PRAGMA journal_mode = WAL;");
 
 // Drizzle instances with schemas
 export const minecraftDb = drizzle(minecraftSqlite, {
@@ -38,9 +43,10 @@ export const systemInfoDb = drizzle(systemInfoSqlite, {
 	schema: systemInfoSchema,
 });
 export const opsDb = drizzle(opsSqlite, { schema: opsSchema });
+export const appsDb = drizzle(appsSqlite, { schema: appsSchema });
 
 // Export schemas for easy access
-export { gameServerSchema, coreSchema, systemInfoSchema, opsSchema };
+export { appsSchema, coreSchema, gameServerSchema, opsSchema, systemInfoSchema };
 
 // Graceful shutdown
 process.on("beforeExit", () => {
@@ -48,4 +54,5 @@ process.on("beforeExit", () => {
 	coreSqlite.close();
 	systemInfoSqlite.close();
 	opsSqlite.close();
+	appsSqlite.close();
 });

--- a/apps/nexus/src/routes/private.ts
+++ b/apps/nexus/src/routes/private.ts
@@ -1,5 +1,6 @@
 import { Elysia } from "elysia";
 import logger from "logger";
+import { appRoutes } from "../domains/apps/routes";
 import { gameServerRoutes } from "../domains/game-servers/routes";
 import { opsRoutes } from "../domains/ops/routes";
 import { systemInfoRoutes } from "../domains/system-info/routes";
@@ -7,6 +8,7 @@ import { autheliaMiddleware } from "../middleware/authelia";
 
 export const privateRoutes = new Elysia({ prefix: "/api" })
 	.use(autheliaMiddleware)
+	.use(appRoutes)
 	.use(gameServerRoutes)
 	.use(systemInfoRoutes)
 	.use(opsRoutes)


### PR DESCRIPTION
- Create apps domain in Nexus with CRUD API and health check caching
- Add apps.sqlite database for persistent storage
- Create /apps dashboard page with category-grouped grid layout
- Support health check URLs with 30-second TTL status caching
- Add app card with status indicators and hover actions
- Update navigation (TopNav, MobileNav, CommandPalette) with apps link
- Add g+a keyboard shortcut for quick navigation