### PR TITLE
feat: show Postgres schema metrics on dashboard

### DIFF
--- a/apps/dashboard/src/lib/ConnectionContext.tsx
+++ b/apps/dashboard/src/lib/ConnectionContext.tsx
@@ -35,6 +35,7 @@ type SystemOverview = {
 		domain: string;
 		sizeBytes: number;
 		sizeFormatted: string;
+		rowCount: number;
 	}>;
 };
 

--- a/apps/dashboard/src/routes/index.tsx
+++ b/apps/dashboard/src/routes/index.tsx
@@ -355,17 +355,19 @@ function HomePage() {
 					className="lg:col-span-2"
 				>
 					{databases.length > 0 ? (
-						<div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+						<div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
 							{databases.map((db) => (
 								<div
 									key={db.name}
 									className="flex items-center gap-2 py-2 px-3 bg-surface-elevated/30 rounded"
 								>
 									<Database size={14} className="text-text-tertiary" />
-									<div className="min-w-0">
+									<div className="min-w-0 flex-1">
 										<div className="text-sm truncate">{db.domain}</div>
-										<div className="text-xs text-text-tertiary tabular-nums">
-											{db.sizeFormatted}
+										<div className="text-xs text-text-tertiary tabular-nums flex gap-2">
+											<span>{db.sizeFormatted}</span>
+											<span>•</span>
+											<span>{db.rowCount?.toLocaleString() ?? 0} rows</span>
 										</div>
 									</div>
 								</div>

--- a/apps/nexus/src/domains/system-info/types.ts
+++ b/apps/nexus/src/domains/system-info/types.ts
@@ -128,6 +128,7 @@ export const DatabaseInfo = t.Object({
 	domain: t.String(),
 	sizeBytes: t.Number(),
 	sizeFormatted: t.String(),
+	rowCount: t.Number(),
 });
 
 export const SystemOverview = t.Object({

--- a/apps/nexus/src/infra/db.ts
+++ b/apps/nexus/src/infra/db.ts
@@ -19,7 +19,7 @@ if (!databaseUrl) {
 	throw new Error("DATABASE_URL is required for Postgres connection in production");
 }
 
-const pgClient = postgres(databaseUrl, {
+export const pgClient = postgres(databaseUrl, {
 	max: 10, // Connection pool size
 	idle_timeout: 20,
 	connect_timeout: 10,


### PR DESCRIPTION
Replace SQLite file size scanning with Postgres schema queries. Now displays schema size and row count for each domain on the dashboard home page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)