### PR TITLE
feat: add standalone nexus-embeddings-worker service

### DIFF
--- a/.github/workflows/nexus-embeddings-worker.yml
+++ b/.github/workflows/nexus-embeddings-worker.yml
@@ -1,0 +1,67 @@
+name: Build Nexus Embeddings Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/nexus-embeddings-worker/**"
+      - "apps/nexus-core/**"
+      - "apps/logger/**"
+      - "apps/k8s/**"
+      - "apps/mc-monitor/**"
+      - "apps/package.json"
+      - "apps/Dockerfile.nexus-embeddings-worker"
+      - ".github/workflows/nexus-embeddings-worker.yml"
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/nexus-embeddings-worker
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=
+            type=ref,event=branch
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./apps
+          file: ./apps/Dockerfile.nexus-embeddings-worker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,40 @@
+# Future Refactoring
+
+## Monorepo Structure Reorganization
+
+Reorganize from flat `apps/` to a cleaner `nexus/` structure:
+
+```
+sb/
+├── nixos/
+├── flux/
+└── nexus/
+    ├── apps/
+    │   ├── api/           # HTTP API (current nexus)
+    │   ├── ui/            # Dashboard
+    │   └── bot/           # Discord bot (the-machine)
+    ├── packages/
+    │   ├── core/          # Shared business logic, schemas, types
+    │   ├── logger/
+    │   ├── k8s/
+    │   └── mc-monitor/    # Protocol library
+    └── workers/
+        ├── agent/         # Agent wake + system events
+        ├── embeddings/
+        └── mc-monitor/    # Status polling service
+```
+
+**Benefits:**
+- Clear taxonomy: apps (interfaces), packages (libraries), workers (background)
+- Dockerfiles colocated with their services
+- Cleaner import paths: `@nexus/core`, `@nexus/logger`
+
+**Migration steps:**
+1. Create new folder structure
+2. Move code to new locations
+3. Update package.json names
+4. Update tsconfig paths
+5. Update bun workspace config
+6. Update GitHub workflows
+7. Update Flux deployments
+8. Update Dockerfiles and their paths

--- a/apps/Dockerfile.nexus-embeddings-worker
+++ b/apps/Dockerfile.nexus-embeddings-worker
@@ -1,0 +1,33 @@
+# Nexus Embeddings Worker Service
+# Generates embeddings via OpenAI and stores in Qdrant
+
+FROM oven/bun:1
+WORKDIR /app
+
+# Copy package files for dependency resolution
+COPY package.json bun.lock ./
+COPY nexus-core/package.json ./nexus-core/
+COPY nexus-embeddings-worker/package.json ./nexus-embeddings-worker/
+COPY logger/package.json ./logger/
+COPY k8s/package.json ./k8s/
+COPY mc-monitor/package.json ./mc-monitor/
+
+# Install production dependencies only
+RUN bun install --frozen-lockfile --production --ignore-scripts
+
+# Copy source code
+COPY logger ./logger/
+COPY k8s ./k8s/
+COPY mc-monitor ./mc-monitor/
+COPY nexus-core ./nexus-core/
+COPY nexus-embeddings-worker ./nexus-embeddings-worker/
+
+ENV NODE_ENV=production
+
+WORKDIR /app/nexus-embeddings-worker
+
+# Run as non-root user
+USER bun
+
+# Start the worker
+CMD ["bun", "src/index.ts"]

--- a/apps/bun.lock
+++ b/apps/bun.lock
@@ -150,6 +150,19 @@
         "typescript": "catalog:",
       },
     },
+    "nexus-embeddings-worker": {
+      "name": "nexus-embeddings-worker",
+      "version": "1.0.0",
+      "dependencies": {
+        "logger": "workspace:*",
+        "nexus-core": "workspace:*",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "catalog:",
+        "bun-types": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "nexus-mc-monitor": {
       "name": "nexus-mc-monitor",
       "version": "1.0.0",
@@ -1184,6 +1197,8 @@
     "nexus-agent-worker": ["nexus-agent-worker@workspace:nexus-agent-worker"],
 
     "nexus-core": ["nexus-core@workspace:nexus-core"],
+
+    "nexus-embeddings-worker": ["nexus-embeddings-worker@workspace:nexus-embeddings-worker"],
 
     "nexus-mc-monitor": ["nexus-mc-monitor@workspace:nexus-mc-monitor"],
 

--- a/apps/nexus-embeddings-worker/package.json
+++ b/apps/nexus-embeddings-worker/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "nexus-embeddings-worker",
+	"version": "1.0.0",
+	"type": "module",
+	"scripts": {
+		"dev": "bun run --watch src/index.ts",
+		"start": "bun run src/index.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"logger": "workspace:*",
+		"nexus-core": "workspace:*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "catalog:",
+		"bun-types": "catalog:",
+		"typescript": "catalog:"
+	}
+}

--- a/apps/nexus-embeddings-worker/src/index.ts
+++ b/apps/nexus-embeddings-worker/src/index.ts
@@ -1,0 +1,64 @@
+/**
+ * Nexus Embeddings Worker - Standalone Embeddings Processing Service
+ *
+ * Generates embeddings for messages using OpenAI and stores them in Qdrant.
+ * This enables semantic search across conversation history.
+ */
+
+import { startEmbeddingsWorker } from "@nexus-core/domains/agent";
+import { config } from "@nexus-core/infra/config";
+import { initializeQdrant } from "@nexus-core/infra/qdrant";
+import { closeQueues } from "@nexus-core/infra/queue";
+import logger from "logger";
+
+const log = logger.child({ service: "nexus-embeddings-worker" });
+
+// Validate required configuration
+if (!config.VALKEY_URL) {
+	log.error("VALKEY_URL is required");
+	process.exit(1);
+}
+
+if (!config.OPENAI_API_KEY) {
+	log.error("OPENAI_API_KEY is required for embeddings generation");
+	process.exit(1);
+}
+
+if (!config.QDRANT_URL) {
+	log.error("QDRANT_URL is required for storing embeddings");
+	process.exit(1);
+}
+
+// Initialize Qdrant collections
+try {
+	await initializeQdrant();
+	log.info("Qdrant initialized");
+} catch (error) {
+	log.error({ error }, "Failed to initialize Qdrant");
+	process.exit(1);
+}
+
+// Start the worker (guaranteed non-null since we validated OPENAI_API_KEY above)
+const embeddingsWorker = startEmbeddingsWorker()!;
+
+log.info(
+	{
+		valkeyUrl: config.VALKEY_URL,
+		qdrantUrl: config.QDRANT_URL,
+		embeddingModel: config.EMBEDDING_MODEL,
+	},
+	"Embeddings worker started"
+);
+
+// Graceful shutdown
+async function shutdown(signal: string) {
+	log.info(`Received ${signal}, shutting down...`);
+
+	await embeddingsWorker.close();
+	await closeQueues();
+
+	process.exit(0);
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/apps/nexus-embeddings-worker/tsconfig.json
+++ b/apps/nexus-embeddings-worker/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../tsconfig.json",
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules"],
+	"compilerOptions": {
+		"lib": ["ES2022"],
+		"types": ["bun-types"],
+		"noEmit": true
+	}
+}

--- a/apps/package.json
+++ b/apps/package.json
@@ -7,6 +7,7 @@
 			"nexus",
 			"nexus-mc-monitor",
 			"nexus-agent-worker",
+			"nexus-embeddings-worker",
 			"the-machine",
 			"dashboard",
 			"logger",

--- a/flux/clusters/superbloom/apps/kustomization.yaml
+++ b/flux/clusters/superbloom/apps/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - qdrant/
   - nexus/
   - nexus-agent-worker/
+  - nexus-embeddings-worker/
   - nexus-mc-monitor/
   - game-servers/

--- a/flux/clusters/superbloom/apps/nexus-embeddings-worker/kustomization.yaml
+++ b/flux/clusters/superbloom/apps/nexus-embeddings-worker/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml

--- a/flux/clusters/superbloom/apps/nexus-embeddings-worker/release.yaml
+++ b/flux/clusters/superbloom/apps/nexus-embeddings-worker/release.yaml
@@ -1,0 +1,39 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nexus-embeddings-worker
+  namespace: nexus
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: app-template
+      version: "4.1.1"
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  values:
+    controllers:
+      main:
+        # Can scale horizontally for more throughput
+        replicas: 1
+        containers:
+          main:
+            image:
+              repository: ghcr.io/saavy1/nexus-embeddings-worker
+              tag: latest
+              pullPolicy: Always
+            env:
+              NODE_ENV: production
+              # External services
+              VALKEY_URL: redis://valkey.valkey.svc.cluster.local:6379
+              QDRANT_URL: http://qdrant.qdrant.svc.cluster.local:6333
+            envFrom:
+              - secretRef:
+                  name: nexus-env
+            # No HTTP probes - worker doesn't expose HTTP
+    # No service needed - doesn't expose HTTP
+    service:
+      main:
+        enabled: false


### PR DESCRIPTION
## Summary
- Extracts embeddings generation into a standalone worker service
- Processes embedding jobs from Valkey queue, generates embeddings via OpenAI, stores in Qdrant
- Adds GitHub Actions workflow for building/pushing Docker image
- Adds Flux HelmRelease for Kubernetes deployment
- Includes TODO.md documenting future monorepo restructuring plan

## Changes
- New `apps/nexus-embeddings-worker/` package with TypeScript worker
- `apps/Dockerfile.nexus-embeddings-worker` - lightweight Docker image
- `.github/workflows/nexus-embeddings-worker.yml` - CI/CD pipeline
- `flux/clusters/superbloom/apps/nexus-embeddings-worker/` - Flux deployment

## Test plan
- [ ] Verify Docker image builds successfully
- [ ] Verify worker connects to Valkey and Qdrant
- [ ] Verify embeddings are generated and stored correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)