### PR TITLE
feat: Add Factory GitHub workflows

### DIFF
--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -1,0 +1,39 @@
+name: Droid Tag
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  droid:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@droid') || contains(github.event.issue.title, '@droid'))) ||
+      (github.event_name == 'pull_request' && (contains(github.event.pull_request.body, '@droid') || contains(github.event.pull_request.title, '@droid')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Run Droid Exec
+        uses: Factory-AI/droid-action@v3
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}


### PR DESCRIPTION
## 🤖 Add Factory GitHub Workflows

This PR adds GitHub Actions workflows to integrate with Factory AI's assistant.

### Workflows Added:
- **@Droid**: Tag @droid in issues and PR comments

### Next Steps:
1. Review the workflow files
2. Add the `FACTORY_API_KEY` secret to your repository:
   - Go to Settings → Secrets and variables → Actions
   - Click "New repository secret"
   - Name: `FACTORY_API_KEY`
   - Generate your API key at [Factory AI Settings](https://app.factory.ai/settings/api-keys)
3. Merge this PR

### Usage:


For more information, see the [Factory AI documentation](https://docs.factory.ai).
