### PR TITLE
fix: resolve Loki STS immutable conflict and provisioned alert dataso…

### DIFF
--- a/argocd/clusters/superbloom/infra/kube-prometheus-stack/values.yaml
+++ b/argocd/clusters/superbloom/infra/kube-prometheus-stack/values.yaml
@@ -69,7 +69,7 @@ grafana:
             - uid: external-secrets-sync-failure
               title: External Secrets Sync Failure
               condition: C
-              for: 10m
+              for: 3m
               noDataState: OK
               execErrState: Error
               data:
@@ -77,7 +77,7 @@ grafana:
                   relativeTimeRange:
                     from: 900
                     to: 0
-                  datasourceUid: loki
+                  datasourceUid: P8E80F9AEF21F6940
                   model:
                     refId: A
                     expr: 'count_over_time({namespace="external-secrets"} |= "UpdateFailed" [15m])'

--- a/argocd/clusters/superbloom/infra/loki/values.yaml
+++ b/argocd/clusters/superbloom/infra/loki/values.yaml
@@ -37,7 +37,10 @@ singleBinary:
   persistence:
     enabled: true
     storageClass: local-path
-    size: 5Gi
+    # Pinned to 10Gi to match the existing StatefulSet's immutable
+    # volumeClaimTemplate. Shrinking the PVC renders an immutable-field diff
+    # that ArgoCD cannot apply, leaving infra-loki stuck OutOfSync.
+    size: 10Gi
   resources:
     requests:
       memory: 512Mi


### PR DESCRIPTION
…urce (closes #77)

- loki: pin singleBinary PVC back to 10Gi to match the existing StatefulSet's immutable volumeClaimTemplate, clearing the OutOfSync immutable-field loop on infra-loki
- kube-prometheus-stack: point the External Secrets Sync Failure alert at the live Loki datasource UID (P8E80F9AEF21F6940) and tighten its 'for' window from 10m to 3m