### PR TITLE
feat(ai): add LFM2.5-350M recipe for KServe MCP testing

### DIFF
--- a/argocd/clusters/superbloom/ai/vllm/recipes/lfm2.5-350m.yaml
+++ b/argocd/clusters/superbloom/ai/vllm/recipes/lfm2.5-350m.yaml
@@ -1,0 +1,36 @@
+id: lfm2.5-350m
+source: spark-arena
+model:
+  id: LiquidAI/LFM2.5-350M
+  revision: null
+  quantization: null
+  gated: false
+  license: apache-2.0
+runtime:
+  image: vllm/vllm-openai:latest
+  args:
+    - --language-model-only
+    - --load-format=fastsafetensors
+    - --attention-backend=flash_attn
+    - --enable-prefix-caching
+    - --enable-chunked-prefill
+    - --trust-remote-code
+    - --dtype=auto
+  env:
+    - VLLM_MARLIN_USE_ATOMIC_ADD=1
+  tensor_parallel: 1
+  max_model_len: 32768
+  dtype: auto
+  tool_call_parser: null
+  reasoning_parser: null
+hardware:
+  gpu_class: gb10
+  gpu_count: 1
+  estimated_vram_gb: 4
+  gpu_memory_utilization: 0.8
+serving:
+  namespace: ai
+  service_name: lfm2.5-350m
+  replicas: 1
+  storage_mode: model-cache
+  ingress_policy: cluster-local


### PR DESCRIPTION
Closes the recipe gap for testing KServe MCP.

Translating from spark-arena config:
- LiquidAI/LFM2.5-350M (350M params, tiny)
- vLLM with flash attention, prefix caching, chunked prefill
- ~4GB VRAM, fits easily on GB10
- auto dtype, language-model-only, trust-remote-code

Also sets `VLLM_MARLIN_USE_ATOMIC_ADD=1` as recommended.